### PR TITLE
Add interactive availability grid for teachers

### DIFF
--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -254,9 +254,17 @@ class IndexController extends Controller
         ];
 
         $out = [];
-        foreach ($availability as $day => $times) {
+        foreach ($availability as $day => $slots) {
             $shortDay = $dayShort[strtolower($day)] ?? strtolower(substr($day, 0, 3));
-            $out[$shortDay] = $this->glueDayNoGapsShort(is_array($times) ? $times : []);
+            $times = [];
+            if (is_array($slots)) {
+                foreach ($slots as $hour => $state) {
+                    if (strtoupper($state) !== 'UNAVAILABLE') {
+                        $times[] = sprintf('%02d:00', (int)$hour);
+                    }
+                }
+            }
+            $out[$shortDay] = $this->glueDayNoGapsShort($times);
         }
         return $out;
     }

--- a/app/Jobs/OptimizeTeachers.php
+++ b/app/Jobs/OptimizeTeachers.php
@@ -138,9 +138,17 @@ class OptimizeTeachers implements ShouldQueue
         ];
 
         $out = [];
-        foreach ($availability as $day => $times) {
+        foreach ($availability as $day => $slots) {
             $shortDay = $dayShort[strtolower($day)] ?? strtolower(substr($day, 0, 3));
-            $out[$shortDay] = $this->glueDayNoGapsShort(is_array($times) ? $times : []);
+            $times = [];
+            if (is_array($slots)) {
+                foreach ($slots as $hour => $state) {
+                    if (strtoupper($state) !== 'UNAVAILABLE') {
+                        $times[] = sprintf('%02d:00', (int)$hour);
+                    }
+                }
+            }
+            $out[$shortDay] = $this->glueDayNoGapsShort($times);
         }
         return $out;
     }

--- a/resources/views/components/availability-dropdown.blade.php
+++ b/resources/views/components/availability-dropdown.blade.php
@@ -19,10 +19,18 @@
         @if(!empty($availability) && is_array($availability))
             <ul class="divide-y divide-gray-100 text-sm max-h-64 overflow-y-auto">
                 @foreach($availability as $day => $slots)
-                    <li class="flex justify-between px-4 py-2">
-                        <span class="capitalize">{{ $day }}</span>
-                        <span class="text-gray-500">{{ implode(', ', $slots) }}</span>
-                    </li>
+                    @php
+                        $display = collect($slots ?? [])
+                            ->filter(fn($state) => strtoupper($state) !== 'UNAVAILABLE')
+                            ->map(fn($state, $hour) => sprintf('%02d:00', (int)$hour) . ' ' . $state)
+                            ->implode(', ');
+                    @endphp
+                    @if($display !== '')
+                        <li class="flex justify-between px-4 py-2">
+                            <span class="capitalize">{{ $day }}</span>
+                            <span class="text-gray-500">{{ $display }}</span>
+                        </li>
+                    @endif
                 @endforeach
             </ul>
         @else

--- a/resources/views/livewire/teachers/availability-grid.blade.php
+++ b/resources/views/livewire/teachers/availability-grid.blade.php
@@ -1,0 +1,68 @@
+@php
+    $days = ['monday','tuesday','wednesday','thursday','friday'];
+    $hours = [9,10,11,12,13,14,15,16];
+@endphp
+<div x-data="availabilityGrid(@entangle('availability').defer)">
+    <table class="table-fixed border-collapse">
+        <thead>
+            <tr>
+                <th class="w-20"></th>
+                @foreach($days as $day)
+                    <th class="px-2 py-1 text-xs font-medium cursor-pointer" @click="toggleColumn('{{ $day }}')">{{ ucfirst($day) }}</th>
+                @endforeach
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($hours as $hour)
+                <tr>
+                    <th class="px-2 py-1 text-xs cursor-pointer" @click="toggleRow({{ $hour }})">{{ sprintf('%02d:00', $hour) }}</th>
+                    @foreach($days as $day)
+                        <td class="border w-16 h-8 text-[10px] text-center cursor-pointer" :class="stateClass(matrix['{{ $day }}'][{{ $hour }}])" @click="cycleState('{{ $day }}', {{ $hour }})" x-text="matrix['{{ $day }}'][{{ $hour }}]"></td>
+                    @endforeach
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@once
+    <script>
+        function availabilityGrid(model) {
+            return {
+                matrix: model || {},
+                states: ['CLASS','ONLINE','HYBRID','UNAVAILABLE'],
+                init() {
+                    const days = ['monday','tuesday','wednesday','thursday','friday'];
+                    const hours = [9,10,11,12,13,14,15,16];
+                    days.forEach(day => {
+                        if(!this.matrix[day]) this.matrix[day] = {};
+                        hours.forEach(hour => {
+                            if(!this.matrix[day][hour]) this.matrix[day][hour] = 'UNAVAILABLE';
+                        });
+                    });
+                },
+                cycleState(day, hour) {
+                    const current = this.matrix[day][hour];
+                    const index = this.states.indexOf(current);
+                    const next = this.states[(index + 1) % this.states.length];
+                    this.matrix[day][hour] = next;
+                },
+                toggleRow(hour) {
+                    const days = Object.keys(this.matrix);
+                    days.forEach(day => this.cycleState(day, hour));
+                },
+                toggleColumn(day) {
+                    const hours = Object.keys(this.matrix[day] || {});
+                    hours.forEach(hour => this.cycleState(day, hour));
+                },
+                stateClass(state) {
+                    return {
+                        'CLASS': 'bg-green-300',
+                        'ONLINE': 'bg-blue-300',
+                        'HYBRID': 'bg-yellow-300',
+                        'UNAVAILABLE': 'bg-gray-200'
+                    }[state] || '';
+                }
+            }
+        }
+    </script>
+@endonce

--- a/resources/views/livewire/teachers/edit.blade.php
+++ b/resources/views/livewire/teachers/edit.blade.php
@@ -2,6 +2,11 @@
     <form wire:submit.prevent="save">
         {{ $this->form }}
 
+        <div class="mt-6">
+            <h3 class="text-sm font-semibold mb-2">Availability</h3>
+            @include('livewire.teachers.availability-grid')
+        </div>
+
         <div class="mt-4 flex justify-end gap-4">
             <a href="/admin/teachers" class="btn-cancel">
                 Cancel


### PR DESCRIPTION
## Summary
- Replace checkbox matrix with interactive availability grid allowing CLASS, ONLINE, HYBRID, and UNAVAILABLE states
- Store teacher availability by day and hour and show it via updated dropdown component
- Adjust schedule optimizer to handle new availability format

## Testing
- `php -l app/Livewire/Teachers/Edit.php`
- `php -l app/Jobs/OptimizeTeachers.php`
- `php -l app/Http/Controllers/Schedule/IndexController.php`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7f80d2608322bfacaf6fc472cd58