### PR TITLE
Unify teacher schedule routes

### DIFF
--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -49,41 +49,19 @@ class IndexController extends Controller
         ]);
     }
 
-    public function teachers()
+    public function teachers(int $teacher_id = null)
     {
-        $lessons = Lesson::with(['subject', 'teachers.user'])->get();
-
-        $events = $lessons->map(function ($lesson) {
-            return [
-                'id' => $lesson->id,
-                'title' => $lesson->subject->code,
-                'color' => $lesson->subject->color,
-                'start' => $lesson->date . 'T' . $lesson->start_time,
-                'end' => $lesson->date . 'T' . $lesson->end_time,
-                'extendedProps' => [
-                    'reason' => $lesson->reason,
-                    'room' => $lesson->room->code,
-                    'teachers' => $lesson->teachers
-                        ->map(fn($teacher) => $teacher->user->name)
-                        ->join(', '),
-                ],
-            ];
-        });
-
-        return view('schedule.index.teachers', [
-            'teacher' => null,
-            'events' => $events,
-            'subjects' => Subject::with('teachers.user')->get(),
-        ]);
-    }
-
-    public function teacher(int $teacher_id)
-    {
-        $teacher = Teacher::findOrFail($teacher_id);
-
-        $lessons = $teacher->lessons()
-            ->with(['subject', 'room', 'teachers.user'])
-            ->get();
+        if ($teacher_id) {
+            $teacher = Teacher::findOrFail($teacher_id);
+            $lessons = $teacher->lessons()
+                ->with(['subject', 'room', 'teachers.user'])
+                ->get();
+            $subjects = $teacher->subjects()->with('teachers.user')->get();
+        } else {
+            $teacher = null;
+            $lessons = Lesson::with(['subject', 'room', 'teachers.user'])->get();
+            $subjects = Subject::with('teachers.user')->get();
+        }
 
         $events = $lessons->map(function ($lesson) {
             return [
@@ -105,7 +83,7 @@ class IndexController extends Controller
         return view('schedule.index.teachers', [
             'teacher' => $teacher,
             'events' => $events,
-            'subjects' => $teacher->subjects()->with('teachers.user')->get(),
+            'subjects' => $subjects,
         ]);
     }
 

--- a/app/Livewire/Teachers/Table.php
+++ b/app/Livewire/Teachers/Table.php
@@ -29,7 +29,7 @@ class Table extends DataTableComponent
             Column::make('Name', 'name')->sortable()->searchable(),
 
             Column::make('Schedule')
-                ->label(fn($row) => view('components.schedule-link', ['link' => '/schedule/index/teacher/teacher_id/'.$row->teacher->id]))
+                ->label(fn($row) => view('components.schedule-link', ['link' => '/schedule/index/teachers/teacher_id/'.$row->teacher->id]))
                 ->html(),
 
             Column::make('Subjects')


### PR DESCRIPTION
## Summary
- merge teacher schedule listing and single-teacher views into one endpoint
- update teacher table link to point at unified schedule route

## Testing
- `composer test` *(fails: requires vendor/autoload.php)*
- `composer install` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689cc3b556a48322947633f64e622640