### PR TITLE
Load schedule data weekly and track remaining subject quantities

### DIFF
--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -51,6 +51,34 @@ class LessonController extends Controller
         ]);
     }
 
+    public function createForTeacher(int $teacher_id, int $subject_id, string $date, string $start_time)
+    {
+        $teacher = Teacher::with('user')->findOrFail($teacher_id);
+        $subject = Subject::findOrFail($subject_id);
+        $room    = Room::first();
+
+        $end_time = Carbon::createFromFormat('H:i', $start_time)
+            ->addMinutes(45)
+            ->format('H:i');
+
+        $lesson = Lesson::create([
+            'subject_id' => $subject->id,
+            'room_id'    => $room->id,
+            'date'       => $date,
+            'start_time' => $start_time,
+            'end_time'   => $end_time,
+        ]);
+
+        $lesson->teachers()->attach($teacher->id);
+
+        return response()->json([
+            'id'       => $lesson->id,
+            'title'    => $subject->code ?? $subject->name,
+            'room'     => $room->code ?? $room->name,
+            'teachers' => $teacher->user?->name,
+        ]);
+    }
+
     public function autoFillTeacher(int $teacher_id, string $start)
     {
         $periods = config('periods');


### PR DESCRIPTION
## Summary
- Serve teacher schedules and subject palettes per week with remaining lesson counts
- Enable creating lessons for a teacher and return metadata for calendar updates
- Dynamically load weekly lessons/subjects in the calendar UI and decrease counts when scheduled

## Testing
- `php -l app/Http/Controllers/Schedule/IndexController.php`
- `php -l app/Http/Controllers/Schedule/LessonController.php`
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ccebf00208322a591795e68c7f006