### PR TITLE
Use subject-based lesson creation and show loading spinner

### DIFF
--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -51,34 +51,6 @@ class LessonController extends Controller
         ]);
     }
 
-    public function createForTeacher(int $teacher_id, int $subject_id, string $date, string $start_time)
-    {
-        $teacher = Teacher::with('user')->findOrFail($teacher_id);
-        $subject = Subject::findOrFail($subject_id);
-        $room    = Room::first();
-
-        $end_time = Carbon::createFromFormat('H:i', $start_time)
-            ->addMinutes(45)
-            ->format('H:i');
-
-        $lesson = Lesson::create([
-            'subject_id' => $subject->id,
-            'room_id'    => $room->id,
-            'date'       => $date,
-            'start_time' => $start_time,
-            'end_time'   => $end_time,
-        ]);
-
-        $lesson->teachers()->attach($teacher->id);
-
-        return response()->json([
-            'id'       => $lesson->id,
-            'title'    => $subject->code ?? $subject->name,
-            'room'     => $room->code ?? $room->name,
-            'teachers' => $teacher->user?->name,
-        ]);
-    }
-
     public function autoFillTeacher(int $teacher_id, string $start)
     {
         $periods = config('periods');

--- a/resources/views/schedule/index/teachers.blade.php
+++ b/resources/views/schedule/index/teachers.blade.php
@@ -167,7 +167,7 @@
                     loadWeekData(info.start);
                 },
 
-                // When a subject pill is dropped onto the calendar: create lesson for THIS teacher
+                // When a subject pill is dropped onto the calendar: create lesson from the subject
                 eventReceive(info) {
                     const subjectId = info.event.extendedProps.subjectId;
                     const start = info.event.start;
@@ -178,7 +178,7 @@
                     const date = toLocalYMD(start);
                     const startTime = formatTime(start);
 
-                    fetch(`/schedule/lesson/createForTeacher/teacher_id/${teacherId}/subject_id/${subjectId}/date/${date}/start_time/${startTime}`)
+                    fetch(`/schedule/lesson/createFromSubject/subject_id/${subjectId}/date/${date}/start_time/${startTime}`)
                         .then(res => res.json())
                         .then(data => {
                             if (!data?.id) throw new Error('Creation failed');
@@ -301,13 +301,17 @@
 
             function loadWeekData(dateObj) {
                 const monday = toLocalYMD(dateObj);
+                const spinner = document.getElementById('spinner');
+                spinner.classList.remove('hidden');
                 fetch(`/schedule/index/teachersData/teacher_id/${teacherId}/start/${monday}`)
                     .then(res => res.json())
                     .then(data => {
                         calendar.removeAllEvents();
                         calendar.addEventSource(data.events || []);
                         renderSubjects(data.subjects || []);
-                    });
+                    })
+                    .catch(() => {})
+                    .finally(() => spinner.classList.add('hidden'));
             }
 
             function renderSubjects(subjects) {


### PR DESCRIPTION
## Summary
- Remove `createForTeacher` backend method and rely on `createFromSubject`
- Switch teacher schedule drag-drop to call `createFromSubject`
- Show a spinner while loading weekly teacher data

## Testing
- ⚠️ `./vendor/bin/phpunit` (phpunit missing; composer install failed with GitHub 403)

------
https://chatgpt.com/codex/tasks/task_e_689cd3fccfa883228445c1fcdcedd653