### PR TITLE
Use subject-based lesson creation and show loading spinner

### DIFF
--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -51,34 +51,6 @@ class LessonController extends Controller
         ]);
     }
 
-    public function createForTeacher(int $teacher_id, int $subject_id, string $date, string $start_time)
-    {
-        $teacher = Teacher::with('user')->findOrFail($teacher_id);
-        $subject = Subject::findOrFail($subject_id);
-        $room    = Room::first();
-
-        $end_time = Carbon::createFromFormat('H:i', $start_time)
-            ->addMinutes(45)
-            ->format('H:i');
-
-        $lesson = Lesson::create([
-            'subject_id' => $subject->id,
-            'room_id'    => $room->id,
-            'date'       => $date,
-            'start_time' => $start_time,
-            'end_time'   => $end_time,
-        ]);
-
-        $lesson->teachers()->attach($teacher->id);
-
-        return response()->json([
-            'id'       => $lesson->id,
-            'title'    => $subject->code ?? $subject->name,
-            'room'     => $room->code ?? $room->name,
-            'teachers' => $teacher->user?->name,
-        ]);
-    }
-
     public function autoFillTeacher(int $teacher_id, string $start)
     {
         $periods = config('periods');


### PR DESCRIPTION
## Summary
- Remove `createForTeacher` backend method and rely on `createFromSubject`
- Switch teacher schedule drag-drop to call `createFromSubject`
- Show a spinner while loading weekly teacher data
- Destroy existing subject draggable before reinitializing to prevent duplicate events

## Testing
- ❌ `./vendor/bin/phpunit` (No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689cd3fccfa883228445c1fcdcedd653