### PR TITLE
Add table-based teacher schedule grid

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Schedule;
+
+use App\Http\Controllers\Controller;
+use App\Models\Teacher;
+use Illuminate\Support\Facades\Config;
+
+class GridController extends Controller
+{
+    public function teachers(?int $teacher_id = null)
+    {
+        $teacher = $teacher_id ? Teacher::findOrFail($teacher_id) : null;
+        $periods = Config::get('periods');
+
+        return view('schedule.grid.teachers', [
+            'teacher' => $teacher,
+            'periods' => $periods,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -117,6 +117,8 @@ class IndexController extends Controller
                 'color' => $lesson->subject->color,
                 'start' => $lesson->date . 'T' . $lesson->start_time,
                 'end' => $lesson->date . 'T' . $lesson->end_time,
+                'date' => $lesson->date,
+                'period' => $lesson->period,
                 'extendedProps' => [
                     'reason' => $lesson->reason,
                     'room' => $lesson->room->code,

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -10,6 +10,7 @@ class Lesson extends Model
         'subject_id',
         'room_id',
         'date',
+        'period',
         'start_time',
         'end_time',
     ];

--- a/database/migrations/2025_08_14_000000_add_period_to_lessons_table.php
+++ b/database/migrations/2025_08_14_000000_add_period_to_lessons_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->unsignedTinyInteger('period')->after('date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->dropColumn('period');
+        });
+    }
+};

--- a/resources/views/schedule/grid/teachers.blade.php
+++ b/resources/views/schedule/grid/teachers.blade.php
@@ -1,0 +1,177 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4 flex gap-4">
+    {{-- Left: Subject palette --}}
+    <div class="w-1/4">
+        <h1 class="text-lg font-semibold mb-3">
+            Teacher schedule{{ $teacher ? ': ' . ($teacher->user->name ?? 'Teacher') : '' }}
+            <span id="spinner" class="hidden">
+                <svg class="animate-spin h-4 w-4 text-gray-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                </svg>
+            </span>
+        </h1>
+        <h2 class="text-sm font-semibold mb-2">Subjects</h2>
+        <div id="subject-palette"></div>
+    </div>
+
+    {{-- Right: Grid --}}
+    <div class="flex-1">
+        <div class="flex items-center mb-2 gap-2">
+            <button id="prev-week" class="px-2 py-1 bg-gray-200 rounded">Prev</button>
+            <div id="week-label" class="font-semibold"></div>
+            <button id="next-week" class="px-2 py-1 bg-gray-200 rounded">Next</button>
+            <button id="fill-week" class="ml-auto px-2 py-1 bg-blue-500 text-white rounded">Fill week</button>
+        </div>
+        <table id="schedule-table" class="w-full table-fixed border">
+            <thead>
+                <tr>
+                    <th class="w-24"></th>
+                    <th class="text-center">Mon</th>
+                    <th class="text-center">Tue</th>
+                    <th class="text-center">Wed</th>
+                    <th class="text-center">Thu</th>
+                    <th class="text-center">Fri</th>
+                </tr>
+            </thead>
+            <tbody>
+                  @foreach($periods as $num => $period)
+                  <tr>
+                      <th class="border px-2 py-1 text-sm">Period {{ $num }}</th>
+                      @for($day = 1; $day <= 5; $day++)
+                          <td class="border h-16 align-top" data-period="{{ $num }}" data-day="{{ $day }}"></td>
+                      @endfor
+                  </tr>
+                  @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const teacherId = {{ $teacher->id ?? 0 }};
+    const table = document.getElementById('schedule-table');
+    const subjectPalette = document.getElementById('subject-palette');
+    let currentMonday = startOfWeek(new Date());
+    let dragType = null;
+
+    function startOfWeek(d){
+        const date = new Date(d);
+        const day = date.getDay();
+        const diff = date.getDate() - day + (day === 0 ? -6 : 1);
+        return new Date(date.setDate(diff));
+    }
+    function formatYMD(d){
+        const y=d.getFullYear();
+        const m=('0'+(d.getMonth()+1)).slice(-2);
+        const da=('0'+d.getDate()).slice(-2);
+        return `${y}-${m}-${da}`;
+    }
+    function loadWeek(){
+        const start = formatYMD(currentMonday);
+        document.getElementById('week-label').textContent = start;
+        fetch(`/schedule/index/teachersData/teacher_id/${teacherId}/start/${start}`)
+            .then(r=>r.json())
+            .then(data=>{
+                renderSubjects(data.subjects || []);
+                clearLessons();
+                (data.events||[]).forEach(addLessonToTable);
+            });
+    }
+    function clearLessons(){
+        table.querySelectorAll('td').forEach(td=>td.innerHTML='');
+    }
+    function renderSubjects(subjects){
+        subjectPalette.innerHTML='';
+        subjects.forEach(sub=>{
+            const div=document.createElement('div');
+            div.className='subject-item cursor-pointer text-white px-2 py-1 rounded mb-2';
+            div.draggable=true;
+            div.dataset.subjectId=sub.id;
+            div.dataset.label=sub.code || sub.name;
+            div.dataset.quantity=sub.quantity;
+            div.style.backgroundColor=sub.color || '#64748b';
+            div.textContent=`${div.dataset.label} (${sub.quantity})`;
+            subjectPalette.appendChild(div);
+        });
+    }
+    function addLessonToTable(ev){
+        const date = new Date(ev.date);
+        const day = date.getDay();
+        const period = ev.period;
+        if(!period) return;
+        const cell = table.querySelector(`td[data-day="${day}"][data-period="${period}"]`);
+        if(!cell) return;
+        const lesson=document.createElement('div');
+        lesson.className='lesson text-xs text-white px-1 py-1 rounded mb-1';
+        lesson.draggable=true;
+        lesson.style.backgroundColor=ev.color || '#64748b';
+        lesson.dataset.id=ev.id;
+        lesson.innerHTML = `<span>${ev.title}</span> <button class="delete-btn ml-1" data-id="${ev.id}">x</button>`;
+        cell.appendChild(lesson);
+    }
+
+    subjectPalette.addEventListener('dragstart', e=>{
+        if(e.target.classList.contains('subject-item')){
+            dragType = 'subject';
+            e.dataTransfer.setData('subjectId', e.target.dataset.subjectId);
+        }
+    });
+    table.addEventListener('dragstart', e=>{
+        if(e.target.classList.contains('lesson')){
+            dragType = 'lesson';
+            e.dataTransfer.setData('lessonId', e.target.dataset.id);
+        }
+    });
+    table.addEventListener('dragover', e=>{ e.preventDefault(); });
+      table.addEventListener('drop', e=>{
+          const cell = e.target.closest('td[data-day]');
+          if(!cell) return;
+          const day = parseInt(cell.dataset.day,10);
+          const period = cell.dataset.period;
+          const date = new Date(currentMonday);
+          date.setDate(date.getDate()+day-1);
+          const ymd = formatYMD(date);
+          if(dragType==='subject'){
+              const subjectId = e.dataTransfer.getData('subjectId');
+              fetch(`/schedule/lesson/createFromSubject/subject_id/${subjectId}/date/${ymd}/period/${period}`)
+                  .then(r=>r.json())
+                  .then(data=>{
+                      addLessonToTable({id:data.id,title:data.title,color:data.color,date:ymd,period:period});
+                      decreaseSubjectQuantity(subjectId);
+                  });
+          } else if(dragType==='lesson'){
+              const lessonId = e.dataTransfer.getData('lessonId');
+              fetch(`/schedule/lesson/update/lesson_id/${lessonId}/date/${ymd}/period/${period}`)
+                  .then(()=> loadWeek());
+          }
+      });
+    table.addEventListener('click', e=>{
+        if(e.target.classList.contains('delete-btn')){
+            const id = e.target.dataset.id;
+            fetch(`/schedule/lesson/delete/lesson_id/${id}`).then(()=> loadWeek());
+        }
+    });
+    function decreaseSubjectQuantity(id){
+        const el = subjectPalette.querySelector(`.subject-item[data-subject-id="${id}"]`);
+        if(!el) return;
+        let qty = parseInt(el.dataset.quantity,10)-1;
+        if(qty<=0) el.remove();
+        else { el.dataset.quantity=qty; el.textContent=`${el.dataset.label} (${qty})`; }
+    }
+    document.getElementById('prev-week').addEventListener('click',()=>{ currentMonday.setDate(currentMonday.getDate()-7); loadWeek(); });
+    document.getElementById('next-week').addEventListener('click',()=>{ currentMonday.setDate(currentMonday.getDate()+7); loadWeek(); });
+    document.getElementById('fill-week').addEventListener('click',()=>{
+        const monday = formatYMD(currentMonday);
+        window.location.href = `/schedule/lesson/autoFillTeacher/teacher_id/${teacherId}/start/${monday}`;
+    });
+
+    loadWeek();
+});
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- Store period numbers on lessons and expose them in schedule data
- Update lesson creation, updates, and auto-fill to use periods instead of start times
- Simplify teacher grid to show period slots without displaying hours

## Testing
- ⚠️ `composer install` *(failed: requires GitHub token to download packages)*
- ⚠️ `php artisan test` *(failed: vendor autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d9a7e851c8322b4a984367dc34751