### PR TITLE
Use periods and states for teacher availability

### DIFF
--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -243,27 +243,6 @@ class IndexController extends Controller
 
     // In the same class as optimizeTeachers()
 
-    private function glueDayNoGapsShort(array $times): ?string
-    {
-        if (empty($times)) return null;
-
-        // normalize -> unique -> sorted "HH:MM"
-        $times = array_values(array_unique(array_map(function ($t) {
-            $t = trim((string)$t);
-            if ($t === '') return null;
-            if (preg_match('/^\d:\d{2}$/', $t)) $t = '0' . $t; // pad
-            return $t;
-        }, $times)));
-        $times = array_filter($times);
-        if (!$times) return null;
-
-        sort($times, SORT_STRING);
-        $startHour = (int)substr(reset($times), 0, 2);
-        $endHour   = (int)substr(end($times), 0, 2);
-
-        return "{$startHour}-{$endHour}";
-    }
-
     private function compressAvailabilityNoGaps($availability): array
     {
         if (!is_array($availability)) return [];
@@ -282,19 +261,48 @@ class IndexController extends Controller
         $out = [];
         foreach ($availability as $day => $slots) {
             $shortDay = $dayShort[strtolower($day)] ?? strtolower(substr($day, 0, 3));
-            $times = [];
-            if (is_array($slots)) {
-                foreach ($slots as $period => $state) {
-                    if (strtoupper($state) !== 'UNAVAILABLE') {
-                        $start = config("periods.$period.start");
-                        if ($start) {
-                            $times[] = $start;
-                        }
+
+            if (!is_array($slots)) continue;
+
+            ksort($slots, SORT_NUMERIC);
+
+            $currentState = null;
+            $rangeStart   = null;
+            $prevPeriod   = null;
+
+            foreach ($slots as $period => $state) {
+                $periodNumber = (int) $period;
+                $state = strtoupper((string) $state);
+
+                if ($state === 'UNAVAILABLE') {
+                    if ($currentState !== null) {
+                        $out[] = "{$shortDay}:{$rangeStart}-{$prevPeriod}:{$currentState}";
+                        $currentState = null;
+                        $rangeStart   = null;
+                        $prevPeriod   = null;
                     }
+                    continue;
                 }
+
+                if ($currentState === $state && $prevPeriod !== null && $periodNumber === $prevPeriod + 1) {
+                    $prevPeriod = $periodNumber;
+                    continue;
+                }
+
+                if ($currentState !== null) {
+                    $out[] = "{$shortDay}:{$rangeStart}-{$prevPeriod}:{$currentState}";
+                }
+
+                $currentState = $state;
+                $rangeStart   = $periodNumber;
+                $prevPeriod   = $periodNumber;
             }
-            $out[$shortDay] = $this->glueDayNoGapsShort($times);
+
+            if ($currentState !== null) {
+                $out[] = "{$shortDay}:{$rangeStart}-{$prevPeriod}:{$currentState}";
+            }
         }
+
         return $out;
     }
 

--- a/tests/Unit/OptimizeTeachersAvailabilityTest.php
+++ b/tests/Unit/OptimizeTeachersAvailabilityTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\OptimizeTeachers;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class OptimizeTeachersAvailabilityTest extends TestCase
+{
+    public function test_compress_availability_uses_periods_and_states(): void
+    {
+        $job = new OptimizeTeachers('2024-01-01', 'test-job');
+
+        $ref = new ReflectionClass($job);
+        $method = $ref->getMethod('compressAvailabilityNoGaps');
+        $method->setAccessible(true);
+
+        $availability = [
+            'monday'  => [10 => 'CLASS', 11 => 'CLASS', 12 => 'CLASS'],
+            'tuesday' => [4 => 'ONLINE', 5 => 'ONLINE'],
+        ];
+
+        $expected = [
+            'mon:10-12:CLASS',
+            'tue:4-5:ONLINE',
+        ];
+
+        $this->assertSame($expected, $method->invoke($job, $availability));
+    }
+}


### PR DESCRIPTION
## Summary
- include state alongside period ranges when compressing teacher availability
- mirror stateful period compression in schedule index controller
- update unit test to cover state-aware period compression

## Testing
- `APP_KEY=base64:SomeFakeKey1234567890123456789012345678901234567890= vendor/bin/phpunit tests/Unit/OptimizeTeachersAvailabilityTest.php`
- `APP_KEY=base64:SomeFakeKey1234567890123456789012345678901234567890= vendor/bin/phpunit` *(fails: Tests: 26, Errors: 12, Failures: 12)*

------
https://chatgpt.com/codex/tasks/task_e_689e2d92623883228ea7f8f6d278cba0