### PR TITLE
Add read-only room schedule grid

### DIFF
--- a/app/Livewire/Rooms/Table.php
+++ b/app/Livewire/Rooms/Table.php
@@ -25,6 +25,9 @@ class Table extends DataTableComponent
     {
         return [
             Column::make('Room Name', 'name')->sortable()->searchable(),
+            Column::make('Schedule')
+                ->label(fn($row) => view('components.schedule-link', ['link' => '/schedule/grid/rooms/room_id/'.$row->id]))
+                ->html(),
             Column::make('Code', 'code')->sortable()->searchable(),
             Column::make('Capacity', 'capacity')->sortable(),
             Column::make('Purpose', 'purpose')->sortable()->searchable(),

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Lesson;
 
 class Room extends Model
 {
@@ -11,6 +12,11 @@ class Room extends Model
     public function subjects()
     {
         return $this->belongsToMany(Subject::class)->withPivot('priority');
+    }
+
+    public function lessons()
+    {
+        return $this->hasMany(Lesson::class);
     }
 }
 

--- a/resources/views/admin/rooms/index.blade.php
+++ b/resources/views/admin/rooms/index.blade.php
@@ -7,10 +7,14 @@
         <div class="flex items-center justify-between mb-6">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100">Rooms</h1>
 
-            {{-- Create Button --}}
-            <a href="/admin/rooms/create" class="grid-head-button">
-                + Create
-            </a>
+            <div class="flex items-center gap-2">
+                <a href="/schedule/grid/rooms" class="grid-head-button">
+                    Full schedule
+                </a>
+                <a href="/admin/rooms/create" class="grid-head-button">
+                    + Create
+                </a>
+            </div>
 
         </div>
 

--- a/resources/views/schedule/grid/rooms.blade.php
+++ b/resources/views/schedule/grid/rooms.blade.php
@@ -1,0 +1,119 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4 max-w-full">
+    <div class="flex items-center justify-center mb-2 gap-2">
+        <button id="prev-week" class="px-2 py-1 bg-gray-200 rounded">Prev</button>
+        <div id="week-label" class="font-semibold"></div>
+        <button id="next-week" class="px-2 py-1 bg-gray-200 rounded">Next</button>
+    </div>
+    <table id="schedule-table" class="w-full table-fixed border">
+        <thead>
+        <tr>
+            <th class="w-1/6 border"></th>
+            <th class="w-1/6 text-center border" data-day-header="1">Mon</th>
+            <th class="w-1/6 text-center border" data-day-header="2">Tue</th>
+            <th class="w-1/6 text-center border" data-day-header="3">Wed</th>
+            <th class="w-1/6 text-center border" data-day-header="4">Thu</th>
+            <th class="w-1/6 text-center border" data-day-header="5">Fri</th>
+        </tr>
+        </thead>
+        <tbody>
+        @foreach($periods as $num => $time)
+        <tr>
+            <th class="border px-2 py-1 text-sm whitespace-normal leading-tight" style="width: 7rem;">
+                Period {{ $num }}<br>{{ $time['start'] }} | {{ $time['end'] }}
+            </th>
+            @for($day=1; $day<=5; $day++)
+                <td class="border h-16" data-period="{{ $num }}" data-day="{{ $day }}" style="vertical-align: top;"></td>
+            @endfor
+        </tr>
+        @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const roomId = {{ $room->id ?? 0 }};
+    const table = document.getElementById('schedule-table');
+    let currentMonday = startOfWeek(new Date());
+
+    function startOfWeek(d){
+        const date = new Date(d);
+        const day = date.getDay();
+        const diff = date.getDate() - day + (day === 0 ? -6 : 1);
+        return new Date(date.setDate(diff));
+    }
+    function formatYMD(d){
+        const y=d.getFullYear();
+        const m=('0'+(d.getMonth()+1)).slice(-2);
+        const da=('0'+d.getDate()).slice(-2);
+        return `${y}-${m}-${da}`;
+    }
+    function loadWeek(){
+        const start = formatYMD(currentMonday);
+        document.getElementById('week-label').textContent = start;
+        fetch(`/schedule/grid/roomsData/room_id/${roomId}/start/${start}`)
+            .then(r=>r.json())
+            .then(data => {
+                clearLessons();
+                (data.events || []).forEach(addLessonToTable);
+                for (let day=1; day<=5; day++) {
+                    const header = document.querySelector(`[data-day-header="${day}"]`);
+                    if (header) {
+                        const date = new Date(currentMonday);
+                        date.setDate(date.getDate() + (day - 1));
+                        const options = { month: 'short', day: 'numeric' };
+                        const dateStr = date.toLocaleDateString(undefined, options);
+                        const weekday = header.textContent.split(' ')[0];
+                        header.textContent = `${weekday} ${dateStr}`;
+                    }
+                }
+            });
+    }
+    function clearLessons(){ table.querySelectorAll('td').forEach(td=>td.innerHTML=''); }
+    function addLessonToTable(ev){
+        const date = new Date(ev.date);
+        const day = date.getDay();
+        const period = ev.period;
+        if(!period) return;
+        const cell = table.querySelector(`td[data-day="${day}"][data-period="${period}"]`);
+        if(!cell) return;
+        const lesson=document.createElement('div');
+        lesson.className='lesson relative text-xs text-white px-1 py-1 rounded mb-1';
+        lesson.style.backgroundColor=ev.color || '#64748b';
+        const wrap = document.createElement('div');
+        wrap.className = 'flex items-start gap-1';
+        const reasonBtn = document.createElement('span');
+        reasonBtn.className = 'reason-btn cursor-pointer text-white text-xs relative';
+        reasonBtn.textContent = '❓';
+        const tooltip = document.createElement('div');
+        tooltip.className = 'reason-tooltip absolute z-50 left-4 top-4 text-red-600 bg-white border border-red-300 px-3 py-2 text-xs rounded shadow hidden';
+        tooltip.textContent = ev.reason || 'No reason provided.';
+        tooltip.style.width='14rem';
+        reasonBtn.appendChild(tooltip);
+        reasonBtn.addEventListener('click', () => {
+            tooltip.classList.toggle('hidden');
+        });
+        const details = document.createElement('div');
+        details.innerHTML = `
+            <div class="font-semibold">${ev.title || ''}</div>
+            <div class="text-sm text-gray-200">${ev.room || ''}</div>
+            <div class="text-xs text-gray-300">${ev.teachers || ''}</div>
+        `;
+        wrap.appendChild(reasonBtn);
+        wrap.appendChild(details);
+        lesson.appendChild(wrap);
+        cell.appendChild(lesson);
+    }
+
+    document.getElementById('prev-week').addEventListener('click',()=>{ currentMonday.setDate(currentMonday.getDate()-7); loadWeek(); });
+    document.getElementById('next-week').addEventListener('click',()=>{ currentMonday.setDate(currentMonday.getDate()+7); loadWeek(); });
+
+    loadWeek();
+});
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- Display room schedules in grid view with week navigation
- Link room schedule grid from room admin pages
- Support retrieving lessons for rooms via controller and model relation

## Testing
- `php artisan test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_689f0e51c144832295894ab049575494