### PR TITLE
Show student list modal in teacher grid

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -33,7 +33,7 @@ class GridController extends Controller
             $teacher = Teacher::with('subjects')->findOrFail($teacher_id);
 
             $lessons = $teacher->lessons()
-                ->with(['subject', 'room', 'teachers.user'])
+                ->with(['subject', 'room', 'teachers.user', 'users'])
                 ->whereBetween('date', [$startDate->toDateString(), $endDate->toDateString()])
                 ->get();
 
@@ -54,7 +54,7 @@ class GridController extends Controller
                 ];
             })->filter(fn ($row) => $row['quantity'] > 0)->values();
         } else {
-            $lessons = Lesson::with(['subject', 'room', 'teachers.user'])
+            $lessons = Lesson::with(['subject', 'room', 'teachers.user', 'users'])
                 ->whereBetween('date', [$startDate->toDateString(), $endDate->toDateString()])
                 ->get()
                 ->filter(fn($lesson) => optional($lesson->subject)->code !== 'IND');
@@ -89,6 +89,11 @@ class GridController extends Controller
                 'teachers' => $lesson->teachers
                     ->map(fn($teacher) => $teacher->user->name)
                     ->join(', '),
+                'students' => $lesson->users
+                    ->map(fn($user) => [
+                        'id' => $user->id,
+                        'name' => $user->name,
+                    ])->values()->all(),
             ];
         });
 

--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -47,6 +47,7 @@ class LessonController extends Controller
             'teachers' => $subject->teachers
                 ->map(fn($teacher) => $teacher->user->name)
                 ->join(', '),
+            'students' => [],
             'date' => $lesson->date,
             'period' => $lesson->period,
         ]);
@@ -73,6 +74,8 @@ class LessonController extends Controller
         $lesson->teachers()->syncWithoutDetaching($teacherIds);
         $lesson->users()->syncWithoutDetaching([$user_id]);
 
+        $user = User::findOrFail($user_id);
+
         return response()->json([
             'id' => $lesson->id,
             'title' => $lesson->subject->code,
@@ -81,6 +84,10 @@ class LessonController extends Controller
             'teachers' => $subject->teachers
                 ->map(fn($teacher) => $teacher->user->name)
                 ->join(', '),
+            'students' => [[
+                'id' => $user->id,
+                'name' => $user->name,
+            ]],
             'date' => $lesson->date,
             'period' => $lesson->period,
         ]);

--- a/resources/views/schedule/grid/teachers.blade.php
+++ b/resources/views/schedule/grid/teachers.blade.php
@@ -177,10 +177,33 @@ document.addEventListener('DOMContentLoaded', () => {
         details.innerHTML = `
             <div class="font-semibold">${ev.title || ''}</div>
             <div class="text-sm text-gray-200">${ev.room || ''}</div>
-            <div class="text-xs text-gray-300">${ev.teachers || ''}</div>
+            <div class="text-xs text-gray-300 teachers-text">${ev.teachers || ''}</div>
         `;
 
-        wrap.appendChild(reasonBtn);
+        const iconWrap = document.createElement('div');
+        iconWrap.className = 'flex flex-col gap-1';
+        iconWrap.appendChild(reasonBtn);
+
+        if(ev.students && ev.students.length){
+            const studentsBtn = document.createElement('span');
+            studentsBtn.className = 'students-btn cursor-pointer text-white text-xs relative';
+            studentsBtn.textContent = '👥';
+            const list = document.createElement('div');
+            list.className = 'students-list absolute z-50 left-4 top-4 text-blue-600 bg-white border border-blue-300 px-3 py-2 text-xs rounded shadow hidden';
+            ev.students.forEach(s => {
+                const item = document.createElement('div');
+                item.dataset.id = s.id;
+                item.textContent = s.name;
+                list.appendChild(item);
+            });
+            studentsBtn.appendChild(list);
+            studentsBtn.addEventListener('click', () => {
+                list.classList.toggle('hidden');
+            });
+            iconWrap.appendChild(studentsBtn);
+        }
+
+        wrap.appendChild(iconWrap);
         wrap.appendChild(details);
         lesson.appendChild(wrap);
 
@@ -204,7 +227,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     period: period,
                     reason: lesson.querySelector('.reason-tooltip')?.textContent || '',
                     room: lesson.querySelector('.text-sm')?.textContent || '',
-                    teachers: lesson.querySelector('.text-xs')?.textContent || '',
+                    teachers: lesson.querySelector('.teachers-text')?.textContent || '',
+                    students: Array.from(lesson.querySelectorAll('.students-list div')).map(div => ({
+                        id: div.dataset.id,
+                        name: div.textContent,
+                    })),
                 });
             });
         });
@@ -245,7 +272,8 @@ document.addEventListener('DOMContentLoaded', () => {
                           period:period,
                           reason:data.reason,
                           room:data.room,
-                          teachers:data.teachers
+                          teachers:data.teachers,
+                          students:data.students || []
                       });
                       decreaseSubjectQuantity(subjectId);
                   });
@@ -333,6 +361,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                         reason: ev.reason,
                                         room: ev.room ,
                                         teachers: ev.teachers,
+                                        students: ev.students || [],
                                     };
                                 }).filter(e => e.period);
                                 console.log(events);


### PR DESCRIPTION
## Summary
- swap student dropdown for icon-triggered modal on teacher schedule grid
- expose student list to event serialization for saving

## Testing
- `composer test` *(23 failed, 2 passed)*


------
https://chatgpt.com/codex/tasks/task_e_689f8116293c8322bd0c5afa85dce85f