### PR TITLE
feat: list and assign unassigned student lessons

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -203,9 +203,33 @@ class GridController extends Controller
             ];
         });
 
+        $subjectIds = $subjects->pluck('id');
+
+        $unassigned = Lesson::with(['subject', 'room', 'teachers.user'])
+            ->whereBetween('date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->whereIn('subject_id', $subjectIds)
+            ->whereDoesntHave('users')
+            ->get()
+            ->map(function ($lesson) {
+                return [
+                    'id' => $lesson->id,
+                    'title' => $lesson->subject->code,
+                    'color' => $lesson->subject->color,
+                    'date' => $lesson->date,
+                    'period' => $lesson->period,
+                    'reason' => $lesson->reason,
+                    'room' => $lesson->room->code,
+                    'teachers' => $lesson->teachers
+                        ->map(fn($teacher) => $teacher->user->name)
+                        ->join(', '),
+                    'subject_id' => $lesson->subject_id,
+                ];
+            });
+
         return response()->json([
             'events' => $events,
             'subjects' => $subjects,
+            'unassigned' => $unassigned,
         ]);
     }
 }

--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -177,6 +177,26 @@ class LessonController extends Controller
         return response()->json(['success' => true]);
     }
 
+    public function assignToStudent(int $lesson_id, int $user_id)
+    {
+        $lesson = Lesson::with(['subject', 'room', 'teachers.user'])->findOrFail($lesson_id);
+        $lesson->users()->syncWithoutDetaching([$user_id]);
+
+        return response()->json([
+            'id' => $lesson->id,
+            'title' => $lesson->subject->code,
+            'color' => $lesson->subject->color,
+            'date' => $lesson->date,
+            'period' => $lesson->period,
+            'reason' => $lesson->reason,
+            'room' => $lesson->room->code,
+            'teachers' => $lesson->teachers
+                ->map(fn($teacher) => $teacher->user->name)
+                ->join(', '),
+            'subject_id' => $lesson->subject_id,
+        ]);
+    }
+
     public function assignStudentLessons(int $user_id, string $start)
     {
         $startDate = Carbon::parse($start)->startOfWeek(Carbon::MONDAY);


### PR DESCRIPTION
## Summary
- show unassigned lessons needed by a student in the schedule grid
- allow assigning an existing lesson to the student with confirmation
- return unassigned lesson data from student grid endpoint

## Testing
- `composer test` *(fails: Session is missing expected key [errors])*

------
https://chatgpt.com/codex/tasks/task_e_689f81e0bdfc83229c328a57af2e58ab