### PR TITLE
Handle OpenAI errors during schedule optimization

### DIFF
--- a/resources/views/schedule/grid/teachers.blade.php
+++ b/resources/views/schedule/grid/teachers.blade.php
@@ -358,6 +358,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch(`/schedule/index/optimizeTeachers/start/${monday}`)
             .then(res => res.json())
             .then(data => {
+                if (data.error) throw new Error(data.error);
                 jobId = data.jobId;
                 if (!jobId) throw new Error('No job id');
                 const poll = setInterval(() => {
@@ -392,16 +393,16 @@ document.addEventListener('DOMContentLoaded', () => {
                                 spinner.classList.add('hidden');
                             }
                         })
-                        .catch(() => {
+                        .catch(err => {
                             clearInterval(poll);
                             spinner.classList.add('hidden');
-                            alert('Optimization failed');
+                            alert(err.message || 'Optimization failed');
                         });
                 }, 10000);
             })
-            .catch(() => {
+            .catch(err => {
                 spinner.classList.add('hidden');
-                alert('Optimization failed');
+                alert(err.message || 'Optimization failed');
             });
     });
 


### PR DESCRIPTION
## Summary
- Surface OpenAI API errors from ScheduleGenerator
- Propagate generation failures to OptimizeTeachers job and UI
- Alert teachers of optimization errors in grid view

## Testing
- `composer test` *(fails: Vite manifest not found; 23 failed)*

------
https://chatgpt.com/codex/tasks/task_e_689f8c8a39e08322a15a18d25f7de34e