### PR TITLE
Assign students to existing lessons from schedule palette

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -175,7 +175,6 @@ class GridController extends Controller
             ->get();
 
         $subjects = $user->subjects
-            ->filter(fn($s) => $s->code === 'IND')
             ->map(function ($subject) use ($user, $startDate, $endDate) {
                 $lessonsCount = $user->lessons()
                     ->where('subject_id', $subject->id)

--- a/resources/views/schedule/grid/student.blade.php
+++ b/resources/views/schedule/grid/student.blade.php
@@ -147,6 +147,7 @@ document.addEventListener('DOMContentLoaded', () => {
         lesson.draggable=true;
         lesson.style.backgroundColor=ev.color || '#64748b';
         lesson.dataset.id=ev.id;
+        lesson.dataset.subjectCode = ev.title || '';
 
         const delBtn = document.createElement('button');
         delBtn.className = 'delete-btn absolute top-0 right-0 text-xl text-white hover:text-red-300';
@@ -256,8 +257,13 @@ document.addEventListener('DOMContentLoaded', () => {
     table.addEventListener('click', e=>{
         if(e.target.classList.contains('delete-btn')){
             const id = e.target.dataset.id;
+            const lessonEl = e.target.closest('.lesson');
+            const code = lessonEl ? lessonEl.dataset.subjectCode : null;
             if(!confirm('Delete this lesson?')) return;
-            fetch(`/schedule/lesson/delete/lesson_id/${id}`).then(()=> loadWeek());
+            const url = code === 'IND'
+                ? `/schedule/lesson/delete/lesson_id/${id}`
+                : `/schedule/lesson/delete/lesson_id/${id}/user_id/${userId}`;
+            fetch(url).then(()=> loadWeek());
         }
     });
     function decreaseSubjectQuantity(id){


### PR DESCRIPTION
## Summary
- allow students to drag subjects and join matching lessons instead of creating duplicates
- create lessons only when dragging IND subject types
- delete action detaches student unless the lesson is IND

## Testing
- `composer test` *(fails: Session is missing expected key [errors]; 24 failed, 1 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0650229008322be5dfe5ae87d2dce