### PR TITLE
Assign students to existing lessons from schedule palette

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -175,7 +175,6 @@ class GridController extends Controller
             ->get();
 
         $subjects = $user->subjects
-            ->filter(fn($s) => $s->code === 'IND')
             ->map(function ($subject) use ($user, $startDate, $endDate) {
                 $lessonsCount = $user->lessons()
                     ->where('subject_id', $subject->id)
@@ -205,6 +204,7 @@ class GridController extends Controller
                 'teachers' => $lesson->teachers
                     ->map(fn($teacher) => $teacher->user->name)
                     ->join(', '),
+                'subject_id' => $lesson->subject_id,
             ];
         });
 

--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -56,40 +56,68 @@ class LessonController extends Controller
     public function createFromSubjectPeriodStudent($subject_id, $date, $period, $user_id)
     {
         $subject = Subject::with('teachers.user')->findOrFail($subject_id);
-        $room = Room::where('code', 'BIBL')->firstOrFail();
-        $slot = config("periods.$period");
-        $start_time = $slot['start'];
-        $end_time   = $slot['end'];
+        $slot    = config("periods.$period");
+        $user    = User::findOrFail($user_id);
 
-        $lesson = Lesson::create([
-            'subject_id' => $subject_id,
-            'room_id' => $room->id,
-            'date' => $date,
-            'period' => $period,
-            'start_time' => $start_time,
-            'end_time' => $end_time,
-        ]);
+        // If the subject is IND, always create a brand new lesson
+        if ($subject->code === 'IND') {
+            $room       = Room::where('code', 'BIBL')->firstOrFail();
+            $start_time = $slot['start'];
+            $end_time   = $slot['end'];
 
-        $teacherIds = $subject->teachers->pluck('id')->unique()->values()->all();
-        $lesson->teachers()->syncWithoutDetaching($teacherIds);
+            $lesson = Lesson::create([
+                'subject_id' => $subject_id,
+                'room_id'    => $room->id,
+                'date'       => $date,
+                'period'     => $period,
+                'start_time' => $start_time,
+                'end_time'   => $end_time,
+            ]);
+
+            $teacherIds = $subject->teachers->pluck('id')->unique()->values()->all();
+            $lesson->teachers()->syncWithoutDetaching($teacherIds);
+            $lesson->users()->syncWithoutDetaching([$user_id]);
+
+            return response()->json([
+                'id'     => $lesson->id,
+                'title'  => $lesson->subject->code,
+                'color'  => $lesson->subject->color,
+                'room'   => $room->code,
+                'teachers' => $subject->teachers
+                    ->map(fn($teacher) => $teacher->user->name)
+                    ->join(', '),
+                'date'   => $lesson->date,
+                'period' => $lesson->period,
+                'reason' => $lesson->reason,
+                'subject_id' => $lesson->subject_id,
+            ]);
+        }
+
+        // For non-IND subjects, attach the student to an existing lesson
+        $lesson = Lesson::with(['subject', 'room', 'teachers.user'])
+            ->where('subject_id', $subject_id)
+            ->where('date', $date)
+            ->where('period', $period)
+            ->first();
+
+        if (!$lesson) {
+            return response()->json(['message' => 'Lesson not found'], 404);
+        }
+
         $lesson->users()->syncWithoutDetaching([$user_id]);
 
-        $user = User::findOrFail($user_id);
-
         return response()->json([
-            'id' => $lesson->id,
-            'title' => $lesson->subject->code,
-            'color' => $lesson->subject->color,
-            'room' => $room->code,
-            'teachers' => $subject->teachers
+            'id'     => $lesson->id,
+            'title'  => $lesson->subject->code,
+            'color'  => $lesson->subject->color,
+            'room'   => $lesson->room->code,
+            'teachers' => $lesson->teachers
                 ->map(fn($teacher) => $teacher->user->name)
                 ->join(', '),
-            'students' => [[
-                'id' => $user->id,
-                'name' => $user->name,
-            ]],
-            'date' => $lesson->date,
+            'date'   => $lesson->date,
             'period' => $lesson->period,
+            'reason' => $lesson->reason,
+            'subject_id' => $lesson->subject_id,
         ]);
     }
 
@@ -176,10 +204,21 @@ class LessonController extends Controller
         ]);
     }
 
-    public function delete($lesson_id)
+    public function delete(int $lesson_id, ?int $user_id = null)
     {
         $lesson = Lesson::findOrFail($lesson_id);
-        $lesson->delete();
+
+        // If a user id is provided, detach the student first
+        if ($user_id !== null) {
+            $lesson->users()->detach($user_id);
+
+            // remove the lesson entirely when no students remain
+            if ($lesson->users()->count() === 0) {
+                $lesson->delete();
+            }
+        } else {
+            $lesson->delete();
+        }
 
         return response()->json(['success' => true]);
     }


### PR DESCRIPTION
## Summary
- allow students to drag subjects and join matching lessons instead of creating duplicates
- dragging an existing lesson now reassigns the student to a matching lesson, while IND lessons move their date and period
- include subject IDs in schedule data to enable lesson reassignments

## Testing
- `composer test` *(fails: Session is missing expected key [errors]; 23 failed, 2 passed (29 assertions))*

------
https://chatgpt.com/codex/tasks/task_e_68a0650229008322be5dfe5ae87d2dce