### PR TITLE
Handle student lesson drag

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -204,6 +204,7 @@ class GridController extends Controller
                 'teachers' => $lesson->teachers
                     ->map(fn($teacher) => $teacher->user->name)
                     ->join(', '),
+                'subject_id' => $lesson->subject_id,
             ];
         });
 


### PR DESCRIPTION
## Summary
- include subject IDs in student schedule data
- update or reassign lessons when dragged depending on subject

## Testing
- `composer test` *(fails: Session is missing expected key [errors])*

------
https://chatgpt.com/codex/tasks/task_e_68a06ef6c12c83229eb1627445d060d6