### PR TITLE
Add table view for all students schedules

### DIFF
--- a/app/Http/Controllers/Schedule/StudentsController.php
+++ b/app/Http/Controllers/Schedule/StudentsController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Schedule;
+
+use App\Http\Controllers\Controller;
+use App\Models\Lesson;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
+
+class StudentsController extends Controller
+{
+    public function index()
+    {
+        $startDate = Carbon::now()->startOfWeek();
+        $endDate   = (clone $startDate)->addDays(4);
+
+        $days = [
+            1 => 'Mon',
+            2 => 'Tue',
+            3 => 'Wed',
+            4 => 'Thu',
+            5 => 'Fri',
+        ];
+
+        $periods = Config::get('periods');
+
+        $lessons = Lesson::with(['subject', 'users'])
+            ->whereBetween('date', [$startDate->toDateString(), $endDate->toDateString()])
+            ->get();
+
+        $studentLessons = [];
+        foreach ($lessons as $lesson) {
+            foreach ($lesson->users as $user) {
+                $studentLessons[$user->id][$lesson->date][$lesson->period] = $lesson;
+            }
+        }
+
+        $students = User::role('student')->orderBy('name')->get();
+
+        return view('schedule.students.index', [
+            'students'       => $students,
+            'days'           => $days,
+            'periods'        => $periods,
+            'startDate'      => $startDate,
+            'studentLessons' => $studentLessons,
+        ]);
+    }
+}
+

--- a/resources/views/schedule/students/index.blade.php
+++ b/resources/views/schedule/students/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4 overflow-x-auto">
+    <table class="min-w-full border text-sm">
+        <thead>
+            <tr>
+                <th rowspan="2" class="border px-2 py-1 bg-gray-100">Student</th>
+                @foreach($days as $dayLabel)
+                    <th colspan="{{ count($periods) }}" class="border px-2 py-1 text-center bg-gray-100">{{ $dayLabel }}</th>
+                @endforeach
+            </tr>
+            <tr>
+                @foreach($days as $dayNumber => $dayLabel)
+                    @for($i = 1; $i <= count($periods); $i++)
+                        <th class="border px-1 py-1 text-center">{{ $i }}</th>
+                    @endfor
+                @endforeach
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($students as $student)
+                <tr>
+                    <td class="border px-2 py-1">{{ $student->name }}</td>
+                    @foreach($days as $dayNumber => $dayLabel)
+                        @for($period = 1; $period <= count($periods); $period++)
+                            @php
+                                $date = $startDate->copy()->addDays($dayNumber - 1)->toDateString();
+                                $lesson = $studentLessons[$student->id][$date][$period] ?? null;
+                            @endphp
+                            <td class="border px-1 py-1 text-center">
+                                {{ $lesson ? $lesson->subject->code : '' }}
+                            </td>
+                        @endfor
+                    @endforeach
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+@endsection
+


### PR DESCRIPTION
## Summary
- show weekly schedules for all students in a single table
- group header by weekday with seven period columns each

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b68b2438832291ac207d074db987