### PR TITLE
Enable week navigation for student schedule overview

### DIFF
--- a/app/Http/Controllers/Schedule/StudentsController.php
+++ b/app/Http/Controllers/Schedule/StudentsController.php
@@ -10,10 +10,12 @@ use Illuminate\Support\Facades\Config;
 
 class StudentsController extends Controller
 {
-    public function index()
+    public function index(?string $start = null)
     {
-        $startDate = Carbon::now()->startOfWeek();
-        $endDate   = (clone $startDate)->addDays(4);
+        $startDate = $start ? Carbon::parse($start)->startOfWeek() : Carbon::now()->startOfWeek();
+        $prevWeek  = $startDate->copy()->subWeek()->toDateString();
+        $nextWeek  = $startDate->copy()->addWeek()->toDateString();
+        $endDate   = $startDate->copy()->addDays(4);
 
         $days = [
             1 => 'Mon',
@@ -47,11 +49,13 @@ class StudentsController extends Controller
         $students = User::role('student')->orderBy('name')->get();
 
         return view('schedule.students.index', [
-            'students'            => $students,
-            'days'                => $days,
-            'periods'             => $periods,
-            'startDate'           => $startDate,
-            'studentLessons'      => $studentLessons,
+            'students'             => $students,
+            'days'                 => $days,
+            'periods'              => $periods,
+            'startDate'            => $startDate,
+            'prevWeek'             => $prevWeek,
+            'nextWeek'             => $nextWeek,
+            'studentLessons'       => $studentLessons,
             'studentsWithConflict' => $studentsWithConflict,
         ]);
     }

--- a/resources/views/schedule/students/index.blade.php
+++ b/resources/views/schedule/students/index.blade.php
@@ -2,6 +2,11 @@
 
 @section('content')
 <div class="container mx-auto p-4 overflow-x-auto max-w-full">
+    <div class="flex items-center justify-center mb-4 gap-2">
+        <a href="{{ url('/schedule/students/index/start/' . $prevWeek) }}" class="px-2 py-1 bg-gray-200 rounded">Prev</a>
+        <span class="font-semibold">{{ $startDate->toDateString() }}</span>
+        <a href="{{ url('/schedule/students/index/start/' . $nextWeek) }}" class="px-2 py-1 bg-gray-200 rounded">Next</a>
+    </div>
     <table class="min-w-full border text-sm">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- Allow starting week to be set via URL parameter in StudentsController
- Add previous/next week navigation controls to student schedule view

## Testing
- `composer test` *(fails: MissingAppKeyException; many auth feature tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c3da9cf88322a8000cf91675992a