### PR TITLE
Allow teacher optimization with custom prompt

### DIFF
--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -135,9 +135,16 @@ class IndexController extends Controller
         ]);
     }
 
-    public function optimizeTeachers(string $start)
+    public function optimizeTeachers(Request $request, string $start = null)
     {
+        $start = $request->input('start', $start);
+        $prompt = $request->input('prompt', '');
         $jobId = (string) Str::uuid();
+
+        if ($prompt !== '') {
+            Cache::put("optimize_teachers_prompt_{$jobId}", $prompt, now()->addHour());
+        }
+
         OptimizeTeachers::dispatch($start, $jobId);
 
         return response()->json(['jobId' => $jobId]);

--- a/app/Jobs/OptimizeTeachers.php
+++ b/app/Jobs/OptimizeTeachers.php
@@ -111,11 +111,13 @@ class OptimizeTeachers implements ShouldQueue
         $events = collect();
 
         if (count($existingSchedule->toArray())) {
+            $prompt = Cache::get("optimize_teachers_prompt_{$this->jobId}", '');
             $scheduler = new ScheduleGenerator(
                 $lessons->toArray(),
                 $rooms->toArray(),
                 $dates,
-                $students->toArray()
+                $students->toArray(),
+                $prompt
             );
 
             try {

--- a/app/Services/ScheduleGenerator.php
+++ b/app/Services/ScheduleGenerator.php
@@ -10,13 +10,15 @@ class ScheduleGenerator
     protected array $students;
     protected array $rooms;
     protected array $currentSchedule;
+    protected string $userPrompt;
 
-    public function __construct(array $currentSchedule = [], array $rooms = [], string $dates = '', array $students = [])
+    public function __construct(array $currentSchedule = [], array $rooms = [], string $dates = '', array $students = [], string $userPrompt = '')
     {
         $this->currentSchedule = $currentSchedule;
         $this->rooms = $rooms;
         $this->dates = $dates;
         $this->students = $students;
+        $this->userPrompt = $userPrompt;
     }
 
     public function generate(): array
@@ -38,7 +40,7 @@ class ScheduleGenerator
     protected function buildPrompt(array $data): string
     {
         $data = json_encode($data);
-        return <<<PROMPT
+        $prompt = <<<PROMPT
 Given the following data:
 {$data}
 
@@ -55,6 +57,11 @@ Rearrange ALL the lessons to:
 - Lower number means a higher priority
 - Ensure that no room has two different lessons scheduled in the same date and period
 PROMPT;
+        if ($this->userPrompt) {
+            $prompt .= "\n\nAdditional instructions:\n{$this->userPrompt}";
+        }
+
+        return $prompt;
     }
 
     protected function callOpenAi(string $prompt): string

--- a/resources/views/schedule/grid/teachers.blade.php
+++ b/resources/views/schedule/grid/teachers.blade.php
@@ -392,11 +392,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('optimize').addEventListener('click', () => {
+        const promptText = prompt('Enter prompt for optimization');
+        if (promptText === null) return;
         const monday = formatYMD(currentMonday);
         const spinner = document.getElementById('spinner');
         spinner.classList.remove('hidden');
         originalEvents = getCurrentEvents();
-        fetch(`/schedule/index/optimizeTeachers/start/${monday}`)
+        fetch(`/schedule/index/optimizeTeachers`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ start: monday, prompt: promptText })
+        })
             .then(res => res.json())
             .then(data => {
                 if (data.error) throw new Error(data.error);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
 
 use App\Http\Controllers\Auth\LoginController;
 
@@ -9,7 +10,8 @@ Route::post('/login', [LoginController::class, 'login']);
 Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 
 Route::middleware('auth')->group(function () {
-    Route::get('{module?}/{controller?}/{action?}/{params?}', function (
+    Route::match(['get', 'post'], '{module?}/{controller?}/{action?}/{params?}', function (
+        Request $request,
         $module = 'index',
         $controller = 'index',
         $action = 'index',
@@ -35,6 +37,8 @@ Route::middleware('auth')->group(function () {
                 $paramArray[$key] = $value;
             }
         }
+
+        $paramArray = array_merge($request->all(), $paramArray);
 
         return app()->call("$controllerClass@$action", $paramArray);
     })->where('params', '.*');


### PR DESCRIPTION
## Summary
- prompt for custom instructions when optimizing teacher schedules
- cache and reuse prompt during async generation
- enable dynamic routes to handle POST bodies

## Testing
- `composer install`
- `php artisan test` *(fails: Session is missing expected key [errors])*

------
https://chatgpt.com/codex/tasks/task_e_68a317384708832281285f0a9512f1d1