### PR TITLE
Use weekday names in schedule generation

### DIFF
--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -212,7 +212,7 @@ class IndexController extends Controller
         $scheduler = new ScheduleGenerator(
             $existingSchedule->toArray(),
             $rooms->toArray(),
-            '',
+            [],
             $students
         );
 

--- a/app/Jobs/OptimizeTeachers.php
+++ b/app/Jobs/OptimizeTeachers.php
@@ -44,7 +44,11 @@ class OptimizeTeachers implements ShouldQueue
 
         $weekStart = Carbon::parse($this->start)->startOfWeek(Carbon::MONDAY);
         $weekEnd   = $weekStart->copy()->addDays(4);
-        $dates = $weekStart->format('d-m-Y') . ' - ' . $weekEnd->format('d-m-Y');
+        $dates = [];
+        for ($i = 0; $i < 5; $i++) {
+            $date = $weekStart->copy()->addDays($i);
+            $dates[strtolower($date->format('l'))] = $date->toDateString();
+        }
 
         $existingSchedule = Lesson::select('id','date','room_id','subject_id')
             ->whereBetween('date', [$weekStart->toDateString(), $weekEnd->toDateString()])


### PR DESCRIPTION
## Summary
- convert ScheduleGenerator to work with weekday names and map back to dates
- compute weekday/date map in OptimizeTeachers job
- adjust controller usage for new constructor

## Testing
- `php artisan test` (fails: No application encryption key specified)

------
https://chatgpt.com/codex/tasks/task_e_68a585846f208322ad2401b121221a2e