### PR TITLE
Add fixed flag to lessons and teacher grid checkbox

### DIFF
--- a/app/Http/Controllers/Schedule/GridController.php
+++ b/app/Http/Controllers/Schedule/GridController.php
@@ -86,6 +86,7 @@ class GridController extends Controller
                 'period' => $lesson->period,
                 'reason' => $lesson->reason,
                 'room' => $lesson->room->code,
+                'fixed' => $lesson->fixed,
                 'teachers' => $lesson->teachers
                     ->map(fn($teacher) => $teacher->user->name)
                     ->join(', '),

--- a/app/Http/Controllers/Schedule/IndexController.php
+++ b/app/Http/Controllers/Schedule/IndexController.php
@@ -119,6 +119,7 @@ class IndexController extends Controller
                 'end' => $lesson->date . 'T' . $lesson->end_time,
                 'date' => $lesson->date,
                 'period' => $lesson->period,
+                'fixed' => $lesson->fixed,
                 'extendedProps' => [
                     'reason' => $lesson->reason,
                     'room' => $lesson->room->code,

--- a/app/Http/Controllers/Schedule/LessonController.php
+++ b/app/Http/Controllers/Schedule/LessonController.php
@@ -44,6 +44,7 @@ class LessonController extends Controller
             'title' => $lesson->subject->code,
             'color' => $lesson->subject->color,
             'room' => $room->code,
+            'fixed' => $lesson->fixed,
             'teachers' => $subject->teachers
                 ->map(fn($teacher) => $teacher->user->name)
                 ->join(', '),
@@ -83,6 +84,7 @@ class LessonController extends Controller
                 'title'  => $lesson->subject->code,
                 'color'  => $lesson->subject->color,
                 'room'   => $room->code,
+                'fixed'  => $lesson->fixed,
                 'teachers' => $subject->teachers
                     ->map(fn($teacher) => $teacher->user->name)
                     ->join(', '),
@@ -116,6 +118,7 @@ class LessonController extends Controller
             'date'   => $lesson->date,
             'period' => $lesson->period,
             'reason' => $lesson->reason,
+            'fixed'  => $lesson->fixed,
         ]);
     }
 
@@ -199,6 +202,18 @@ class LessonController extends Controller
         return response()->json([
             'status' => 'success',
             'lesson' => $lesson,
+        ]);
+    }
+
+    public function setFixed(int $lesson_id, int $fixed)
+    {
+        $lesson = Lesson::findOrFail($lesson_id);
+        $lesson->fixed = (bool) $fixed;
+        $lesson->save();
+
+        return response()->json([
+            'status' => 'success',
+            'fixed' => $lesson->fixed,
         ]);
     }
 

--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -13,6 +13,7 @@ class Lesson extends Model
         'period',
         'start_time',
         'end_time',
+        'fixed',
     ];
 
     public function subject()

--- a/database/migrations/2025_08_20_000000_add_fixed_to_lessons_table.php
+++ b/database/migrations/2025_08_20_000000_add_fixed_to_lessons_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->boolean('fixed')->default(false)->after('reason');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->dropColumn('fixed');
+        });
+    }
+};

--- a/resources/views/schedule/grid/teachers.blade.php
+++ b/resources/views/schedule/grid/teachers.blade.php
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
             cls += ' text-white';
             lesson.style.backgroundColor=ev.color || '#64748b';
-            lesson.draggable=true;
+            lesson.draggable=!ev.fixed;
             lesson.dataset.id=ev.id;
         }
         lesson.className = cls;
@@ -200,6 +200,13 @@ document.addEventListener('DOMContentLoaded', () => {
             delBtn.dataset.id = ev.id;
             delBtn.textContent = '×';
             lesson.appendChild(delBtn);
+
+            const fixedInput = document.createElement('input');
+            fixedInput.type = 'checkbox';
+            fixedInput.className = 'fixed-checkbox absolute top-0 left-0 m-0.5';
+            fixedInput.dataset.id = ev.id;
+            fixedInput.checked = !!ev.fixed;
+            lesson.appendChild(fixedInput);
         }
 
         const wrap = document.createElement('div');
@@ -304,6 +311,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     reason: lesson.querySelector('.reason-tooltip')?.textContent || '',
                     room: lesson.querySelector('.text-sm')?.textContent || '',
                     teachers: lesson.querySelector('.teachers-text')?.textContent || '',
+                    fixed: lesson.querySelector('.fixed-checkbox')?.checked || false,
                     students: Array.from(lesson.querySelectorAll('.students-list div')).map(div => ({
                         id: div.dataset.id,
                         name: div.textContent,
@@ -395,6 +403,13 @@ document.addEventListener('DOMContentLoaded', () => {
             const id = e.target.dataset.id;
             if(!confirm('Delete this lesson?')) return;
             fetch(`/schedule/lesson/delete/lesson_id/${id}`).then(()=> loadWeek());
+        }
+    });
+    table.addEventListener('change', e=>{
+        if(e.target.classList.contains('fixed-checkbox')){
+            const id = e.target.dataset.id;
+            const fixed = e.target.checked ? 1 : 0;
+            fetch(`/schedule/lesson/setFixed/lesson_id/${id}/fixed/${fixed}`);
         }
     });
     function decreaseSubjectQuantity(id){


### PR DESCRIPTION
## Summary
- allow lessons to be marked as fixed with a new boolean column
- expose fixed state to lesson APIs and support toggling via new controller action
- add a checkbox on the teacher grid to view and change a lesson's fixed status

## Testing
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ddb61b88322ae0b2066cc72f415