### PR TITLE
Switch schedule to version-based lessons

### DIFF
--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -10,11 +10,9 @@ class Lesson extends Model
         'subject_id',
         'room_id',
         'day',
-        'date',
         'period',
-        'start_time',
-        'end_time',
         'fixed',
+        'version_id',
     ];
 
     public function subject()

--- a/database/migrations/2025_08_30_000000_remove_date_time_from_lessons_table.php
+++ b/database/migrations/2025_08_30_000000_remove_date_time_from_lessons_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->dropColumn(['date', 'start_time', 'end_time']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lessons', function (Blueprint $table) {
+            $table->date('date')->nullable();
+            $table->time('start_time')->nullable();
+            $table->time('end_time')->nullable();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Replace week navigation in teacher and room schedules with a version selector
- Retrieve lessons for teachers and rooms by version/day/period and keep auto-fill functionality
- Provide version options to teacher and room grid views
- Restore teacher auto-fill endpoint to generate lessons by day/period for a given version

## Testing
- `composer test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68a7529e4204832282ea768275f51f11