### PR TITLE
Add version creation to teacher schedule grid

### DIFF
--- a/app/Http/Controllers/Schedule/VersionController.php
+++ b/app/Http/Controllers/Schedule/VersionController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Schedule;
+
+use App\Http\Controllers\Controller;
+use App\Models\Version;
+use Illuminate\Http\Request;
+
+class VersionController extends Controller
+{
+    public function create(Request $request)
+    {
+        $name = $request->input('name', '');
+        if ($name === '') {
+            return response()->json(['error' => 'Name is required'], 422);
+        }
+
+        $version = Version::create(['name' => $name]);
+
+        return response()->json(['id' => $version->id]);
+    }
+}

--- a/resources/views/schedule/grid/teachers.blade.php
+++ b/resources/views/schedule/grid/teachers.blade.php
@@ -25,6 +25,7 @@
                     <option value="{{ $v->id }}">{{ $v->name }}</option>
                 @endforeach
             </select>
+            <button id="add-version" class="grid-head-button">Add version</button>
             <button id="fill-week"
                     class="grid-head-button">
                 Fill version
@@ -84,6 +85,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const table = document.getElementById('schedule-table');
     const subjectPalette = document.getElementById('subject-palette');
     const versionSelect = document.getElementById('version-select');
+    const addVersionBtn = document.getElementById('add-version');
+    const params = new URLSearchParams(window.location.search);
+    const urlVersionId = params.get('version_id');
+    if (urlVersionId) {
+        versionSelect.value = urlVersionId;
+    }
     let currentVersion = versionSelect.value;
     let dragType = null;
     const periods = @json($periods);
@@ -100,6 +107,24 @@ document.addEventListener('DOMContentLoaded', () => {
     versionSelect.addEventListener('change', () => {
         currentVersion = versionSelect.value;
         loadVersion();
+    });
+
+    addVersionBtn.addEventListener('click', () => {
+        const name = prompt('Enter version name');
+        if (!name) return;
+        fetch(`/schedule/version/create`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': csrfToken(),
+            },
+            body: JSON.stringify({ name })
+        })
+            .then(r => r.json())
+            .then(data => {
+                let base = teacherId ? `/schedule/grid/teachers/teacher_id/${teacherId}` : '/schedule/grid/teachers';
+                window.location.href = `${base}?version_id=${data.id}`;
+            });
     });
 
     function loadVersion(){


### PR DESCRIPTION
## Summary
- Add controller to create schedule versions
- Add "Add version" button in teacher grid to create version and reload page

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: Required package "phpoffice/phpspreadsheet" is not present in the lock file)*

------
https://chatgpt.com/codex/tasks/task_e_68a77158a00c8322bce544a9a8b800ea